### PR TITLE
Fix incorrect determine length yamlOrJsonGoString

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,8 +19,8 @@ module.exports.parse = (yamlOrJSONDocument, options = {}) => {
 
   yamlOrJSONGoString = new GoString();
   yamlOrJSONGoString['p'] = yamlOrJSONDocument;
-  yamlOrJSONGoString['n'] = yamlOrJSONGoString['p'].length-1;
-  
+  yamlOrJSONGoString['n'] = Buffer.byteLength(yamlOrJSONGoString['p'], 'utf8') - 1;
+
   const parsed = parser.Parse(yamlOrJSONGoString, !!options.circular);
 
   if (parsed.hasErrors) {


### PR DESCRIPTION
I have error for this yaml:

```
asyncapi: '2.0.0-rc1'
id: 'urn:test.dev'
info:
  title: Тестовое апи
  version: '1.0.0'

servers:
  - url: https://test.dev
    protocol: wss

channels:
    /test/:
      subscribe:
        message:
          payload:
            type: string
            examples: ['тестовая строка']
```